### PR TITLE
#11 add CRUD to Stores and Menus

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { ConfigModule } from '@nestjs/config'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { GraphQLModule } from '@nestjs/graphql'
 import { StoresModule } from './stores/stores.module'
+import { MenusModule } from './menus/menus.module'
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { StoresModule } from './stores/stores.module'
       typePaths: ['./**/*.graphql'],
     }),
     StoresModule,
+    MenusModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/graphql.ts
+++ b/apps/api/src/graphql.ts
@@ -16,6 +16,76 @@ export enum Holiday {
     UNKNOWN = "UNKNOWN"
 }
 
+export interface MenuCreateInput {
+    storeId: string;
+    name: string;
+    price: number;
+    description?: Nullable<string>;
+    imageUrl?: Nullable<string>;
+    isLunch: boolean;
+    isDinner: boolean;
+}
+
+export interface MenuUpdateInput {
+    id: string;
+    storeId?: Nullable<string>;
+    name?: Nullable<string>;
+    price?: Nullable<number>;
+    description?: Nullable<string>;
+    imageUrl?: Nullable<string>;
+    isLunch?: Nullable<boolean>;
+    isDinner?: Nullable<boolean>;
+}
+
+export interface StoreCreateInput {
+    name: string;
+    imageUrl?: Nullable<string>;
+    address: string;
+    phone: string;
+    description?: Nullable<string>;
+    holidays?: Nullable<Nullable<Holiday>[]>;
+    isVisible?: Nullable<boolean>;
+}
+
+export interface StoreUpdateInput {
+    id: string;
+    name?: Nullable<string>;
+    imageUrl?: Nullable<string>;
+    address?: Nullable<string>;
+    phone?: Nullable<string>;
+    description?: Nullable<string>;
+    holidays?: Nullable<Nullable<Holiday>[]>;
+    isVisible?: Nullable<boolean>;
+}
+
+export interface Menu {
+    id: string;
+    storeId: string;
+    name: string;
+    price: number;
+    description?: Nullable<string>;
+    imageUrl?: Nullable<string>;
+    isLunch: boolean;
+    isDinner: boolean;
+}
+
+export interface IQuery {
+    menus(): Nullable<Nullable<Menu>[]> | Promise<Nullable<Nullable<Menu>[]>>;
+    menusByStore(storeId: string): Nullable<Nullable<Menu>[]> | Promise<Nullable<Nullable<Menu>[]>>;
+    menu(id: string): Nullable<Menu> | Promise<Nullable<Menu>>;
+    stores(): Nullable<Nullable<Store>[]> | Promise<Nullable<Nullable<Store>[]>>;
+    store(id: string): Nullable<Store> | Promise<Nullable<Store>>;
+}
+
+export interface IMutation {
+    menuCreate(menuCreateInput: MenuCreateInput): Nullable<Menu> | Promise<Nullable<Menu>>;
+    menuUpdate(menuUpdateInput: MenuUpdateInput): Nullable<Menu> | Promise<Nullable<Menu>>;
+    menuDelete(id: string): Nullable<Menu> | Promise<Nullable<Menu>>;
+    storeCreate(storeCreateInput?: Nullable<StoreCreateInput>): Nullable<Store> | Promise<Nullable<Store>>;
+    storeUpdate(storeUpdateInput?: Nullable<StoreUpdateInput>): Nullable<Store> | Promise<Nullable<Store>>;
+    storeDelete(id: string): Nullable<Store> | Promise<Nullable<Store>>;
+}
+
 export interface Store {
     id: string;
     name: string;
@@ -24,11 +94,7 @@ export interface Store {
     phone: string;
     description?: Nullable<string>;
     holidays?: Nullable<Nullable<Holiday>[]>;
-}
-
-export interface IQuery {
-    stores(): Nullable<Nullable<Store>[]> | Promise<Nullable<Nullable<Store>[]>>;
-    store(id: string): Nullable<Store> | Promise<Nullable<Store>>;
+    isVisible: boolean;
 }
 
 type Nullable<T> = T | null;

--- a/apps/api/src/menus/menus.entity.ts
+++ b/apps/api/src/menus/menus.entity.ts
@@ -1,0 +1,28 @@
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm'
+
+@Entity()
+export class Menus {
+  @PrimaryGeneratedColumn()
+  id: string
+
+  @Column()
+  storeId: string
+
+  @Column()
+  name: string
+
+  @Column()
+  price: number
+
+  @Column({ nullable: true })
+  description: string
+
+  @Column({ nullable: true })
+  imageUrl: string
+
+  @Column()
+  isLunch: boolean
+
+  @Column()
+  isDinner: boolean
+}

--- a/apps/api/src/menus/menus.graphql
+++ b/apps/api/src/menus/menus.graphql
@@ -1,0 +1,43 @@
+type Menu {
+  id: ID!
+  storeId: ID!
+  name: String!
+  price: Int!
+  description: String
+  imageUrl: String
+  isLunch: Boolean!
+  isDinner: Boolean!
+}
+
+type Query {
+  menus: [Menu]
+  menusByStore(storeId: ID!): [Menu]
+  menu(id: ID!): Menu
+}
+
+type Mutation {
+  menuCreate(menuCreateInput: MenuCreateInput!): Menu
+  menuUpdate(menuUpdateInput: MenuUpdateInput!): Menu
+  menuDelete(id: ID!): Menu
+}
+
+input MenuCreateInput {
+  storeId: ID!
+  name: String!
+  price: Int!
+  description: String
+  imageUrl: String
+  isLunch: Boolean!
+  isDinner: Boolean!
+}
+
+input MenuUpdateInput {
+  id: ID!
+  storeId: ID
+  name: String
+  price: Int
+  description: String
+  imageUrl: String
+  isLunch: Boolean
+  isDinner: Boolean
+}

--- a/apps/api/src/menus/menus.module.ts
+++ b/apps/api/src/menus/menus.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { MenusService } from './menus.service'
+import { MenusResolver } from './menus.resolver'
+import { Menus } from './menus.entity'
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Menus])],
+  providers: [MenusService, MenusResolver],
+})
+export class MenusModule {}

--- a/apps/api/src/menus/menus.resolver.spec.ts
+++ b/apps/api/src/menus/menus.resolver.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { MenusResolver } from './menus.resolver'
+
+describe('MenusResolver', () => {
+  let resolver: MenusResolver
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MenusResolver],
+    }).compile()
+
+    resolver = module.get<MenusResolver>(MenusResolver)
+  })
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined()
+  })
+})

--- a/apps/api/src/menus/menus.resolver.ts
+++ b/apps/api/src/menus/menus.resolver.ts
@@ -1,0 +1,45 @@
+import { Resolver, Query, Mutation, Args } from '@nestjs/graphql'
+import { MenusService } from './menus.service'
+import { Menu, MenuCreateInput, MenuUpdateInput } from '../graphql'
+
+@Resolver('Menu')
+export class MenusResolver {
+  constructor(private menusService: MenusService) {}
+
+  @Query()
+  async menu(@Args('id') id: string) {
+    return this.menusService.findOne(id)
+  }
+
+  @Query()
+  async menusByStore(@Args('storeId') storeId: string) {
+    return this.menusService.findByStoreId(storeId)
+  }
+
+  @Query()
+  async menus() {
+    return this.menusService.findAll()
+  }
+
+  @Mutation()
+  async menuCreate(
+    @Args('menuCreateInput') args: MenuCreateInput,
+  ): Promise<Menu> {
+    const createdMenu = await this.menusService.create(args)
+    return createdMenu
+  }
+
+  @Mutation()
+  async menuUpdate(
+    @Args('menuUpdateInput') args: MenuUpdateInput,
+  ): Promise<Menu> {
+    const updatedMenu = await this.menusService.update(args)
+    return updatedMenu
+  }
+
+  @Mutation()
+  async menuDelete(@Args('id') id: string): Promise<Menu> {
+    const deletedMenu = await this.menusService.delete(id)
+    return deletedMenu
+  }
+}

--- a/apps/api/src/menus/menus.service.spec.ts
+++ b/apps/api/src/menus/menus.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { MenusService } from './menus.service'
+
+describe('MenusService', () => {
+  let service: MenusService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MenusService],
+    }).compile()
+
+    service = module.get<MenusService>(MenusService)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+})

--- a/apps/api/src/menus/menus.service.ts
+++ b/apps/api/src/menus/menus.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { Repository } from 'typeorm'
+import { Menus } from './menus.entity'
+
+@Injectable()
+export class MenusService {
+  constructor(
+    @InjectRepository(Menus)
+    private readonly menuRepository: Repository<Menus>,
+  ) {}
+
+  async findAll(): Promise<Menus[]> {
+    return await this.menuRepository.find()
+  }
+
+  async findByStoreId(storeId: string): Promise<Menus[]> {
+    return await this.menuRepository.find({ storeId })
+  }
+
+  async findOne(id: string): Promise<Menus> {
+    return await this.menuRepository.findOne(id)
+  }
+
+  async create(menu: Partial<Menus>): Promise<Menus> {
+    return await this.menuRepository.save(menu)
+  }
+
+  async update(menu: Partial<Menus>): Promise<Menus> {
+    return await this.menuRepository.save(menu)
+  }
+
+  async delete(id: string): Promise<Menus> {
+    const menu = await this.menuRepository.findOne(id)
+    await this.menuRepository.delete(id)
+    return menu
+  }
+}

--- a/apps/api/src/stores/stores.entity.ts
+++ b/apps/api/src/stores/stores.entity.ts
@@ -3,13 +3,13 @@ import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm'
 @Entity()
 export class Stores {
   @PrimaryGeneratedColumn()
-  id: number
+  id: string
 
   @Column()
   name: string
 
   @Column({ nullable: true })
-  imageURL: string
+  imageUrl: string
 
   @Column()
   address: string
@@ -25,4 +25,7 @@ export class Stores {
     nullable: true,
   })
   holidays: string[]
+
+  @Column({ default: true })
+  isVisible: boolean
 }

--- a/apps/api/src/stores/stores.graphql
+++ b/apps/api/src/stores/stores.graphql
@@ -9,16 +9,44 @@ enum Holiday {
 }
 
 type Store {
-  id: String!
+  id: ID!
   name: String!
   imageUrl: String
   address: String!
   phone: String!
   description: String
   holidays: [Holiday]
+  isVisible: Boolean!
 }
 
 type Query {
   stores: [Store]
-  store(id: String!): Store
+  store(id: ID!): Store
+}
+
+type Mutation {
+  storeCreate(storeCreateInput: StoreCreateInput): Store
+  storeUpdate(storeUpdateInput: StoreUpdateInput): Store
+  storeDelete(id: ID!): Store
+}
+
+input StoreCreateInput {
+  name: String!
+  imageUrl: String
+  address: String!
+  phone: String!
+  description: String
+  holidays: [Holiday]
+  isVisible: Boolean
+}
+
+input StoreUpdateInput {
+  id: ID!
+  name: String
+  imageUrl: String
+  address: String
+  phone: String
+  description: String
+  holidays: [Holiday]
+  isVisible: Boolean
 }

--- a/apps/api/src/stores/stores.resolver.spec.ts
+++ b/apps/api/src/stores/stores.resolver.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { StoresResolver } from './stores.resolver'
+
+describe('StoresResolver', () => {
+  let resolver: StoresResolver
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [StoresResolver],
+    }).compile()
+
+    resolver = module.get<StoresResolver>(StoresResolver)
+  })
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined()
+  })
+})

--- a/apps/api/src/stores/stores.resolver.ts
+++ b/apps/api/src/stores/stores.resolver.ts
@@ -1,17 +1,49 @@
-import { Resolver, Query, Args } from '@nestjs/graphql'
+import { Resolver, Query, Mutation, Args } from '@nestjs/graphql'
 import { StoresService } from './stores.service'
+import { Holiday, Store, StoreCreateInput, StoreUpdateInput } from '../graphql'
+import { Stores } from './stores.entity'
 
 @Resolver('Store')
 export class StoresResolver {
   constructor(private storesService: StoresService) {}
 
   @Query()
-  async store(@Args('id') id: number) {
+  async store(@Args('id') id: string) {
     return this.storesService.findOne(id)
   }
 
   @Query()
   async stores() {
     return this.storesService.findAll()
+  }
+
+  @Mutation()
+  async storeCreate(
+    @Args('storeCreateInput') args: StoreCreateInput,
+  ): Promise<Store> {
+    const createdStore = await this.storesService.create(args)
+    return convertHolidays(createdStore)
+  }
+
+  @Mutation()
+  async storeUpdate(
+    @Args('menuUpdateInput') args: StoreUpdateInput,
+  ): Promise<Store> {
+    const updatedStore = await this.storesService.update(args)
+    return convertHolidays(updatedStore)
+  }
+
+  @Mutation()
+  async storeDelete(@Args('id') id: string): Promise<Store> {
+    const deletedStore = await this.storesService.delete(id)
+    return convertHolidays(deletedStore)
+  }
+}
+
+const convertHolidays = (store: Stores): Store => {
+  const { holidays } = store
+  return {
+    ...store,
+    holidays: holidays ? (holidays as Holiday[]) : [],
   }
 }

--- a/apps/api/src/stores/stores.service.ts
+++ b/apps/api/src/stores/stores.service.ts
@@ -14,20 +14,19 @@ export class StoresService {
     return await this.storeRepository.find()
   }
 
-  async findOne(id: number): Promise<Stores> {
+  async findOne(id: string): Promise<Stores> {
     return await this.storeRepository.findOne(id)
   }
 
-  async create(store: Stores): Promise<Stores> {
+  async create(store: Partial<Stores>): Promise<Stores> {
     return await this.storeRepository.save(store)
   }
 
-  async update(id: number, store: Stores): Promise<Stores> {
-    store.id = id
+  async update(store: Partial<Stores>): Promise<Stores> {
     return await this.storeRepository.save(store)
   }
 
-  async delete(id: number): Promise<Stores> {
+  async delete(id: string): Promise<Stores> {
     const store = await this.storeRepository.findOne(id)
     await this.storeRepository.delete(id)
     return store


### PR DESCRIPTION
변경점
---
- Menus 모듈 추가
- Menus 관련 CRUD GraphQL mutation 추가
- Stores 관련 CRUD GraphQL mutation 추가
- 자동 생성된 Stores, Menus 테스트용 spec 파일 추가

- Stores 의 imageURL 필드이름을 id, storeId 필드들과의 통일성을 위해 ImageUrl 로 변경
- Stores 의 id, Menus 의 id, storeId 등의 타입을 number 에서 string 으로 변경
	- 일반 SQL 데이터베이스에서 ID는 보통 정수형 타입임
	- No-SQL 기반 데이터베이스(몽고DB, Redis 등)에서는 ID가 문자열 타입인 경우가 많음
	- GraphQL 의 ID 타입은 모든 경우에 대응하기 위해 문자열 타입으로 취급됨
	- GraphQL 스키마와 PostgreSQL 스키마를 Typescript에서 충돌 없이 사용하기 위해 string 타입으로 통일