### PR TITLE
feat: OrderDrawerHeader UI작업완료

### DIFF
--- a/apps/client/components/OrderDrawer.tsx
+++ b/apps/client/components/OrderDrawer.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { NextPage } from 'next'
+import { OrderMenuCard } from './OrderMenu'
 
 import {
   Box,
@@ -9,6 +10,7 @@ import {
   List,
   ListItem,
   ListItemText,
+  Button,
 } from '@mui/material'
 
 interface OrderDrawerProps {
@@ -25,35 +27,40 @@ const OrderDrawer: NextPage<OrderDrawerProps> = ({
     <div>
       <Toolbar />
       <Box sx={{ overflow: 'auto' }}>
-        <Typography variant="h6" align="center">
-          Orders
-        </Typography>
-        <List>
-          <ListItem button key="order1">
-            <ListItemText
-              primary="주문한 음식 1"
-              sx={{ textAlign: 'center' }}
-            />
-          </ListItem>
-          <ListItem button key="order2">
-            <ListItemText
-              primary="주문한 음식 2"
-              sx={{ textAlign: 'center' }}
-            />
-          </ListItem>
-          <ListItem button key="order3">
-            <ListItemText
-              primary="주문한 음식 3"
-              sx={{ textAlign: 'center' }}
-            />
-          </ListItem>
-          <ListItem button key="order4">
-            <ListItemText
-              primary="주문한 음식 4"
-              sx={{ textAlign: 'center' }}
-            />
-          </ListItem>
-        </List>
+        <div style={{ width: '100%' }}>
+          <Box sx={{ display: 'flex', p: 1, bgcolor: 'background.paper' }}>
+            <Box
+              sx={{
+                p: 1,
+                flexGrow: 1,
+                bgcolor: 'white.200',
+                padding: '14px',
+                textAlign: 'right',
+                pt: '18px',
+                pr: '30px',
+              }}
+            >
+              장바구니
+            </Box>
+            <Box sx={{ p: 1, bgcolor: 'white.300' }}>
+              <Button
+                size="small"
+                variant="outlined"
+                sx={{
+                  fontSize: 5,
+                  width: '10px',
+                  px: 3,
+                  ml: 1,
+                  padding: '6px',
+                  mt: '6px',
+                }}
+              >
+                전체삭제
+              </Button>
+            </Box>
+          </Box>
+        </div>
+        <List>{OrderMenuCard}</List>
       </Box>
     </div>
   )

--- a/apps/client/components/OrderMenu.tsx
+++ b/apps/client/components/OrderMenu.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { styled } from '@mui/material/styles'
+import { Grid, Paper, ListItem } from '@mui/material'
+
+// import { NextPage } from 'next'
+// import MenuIcon from '@mui/icons-material/Menu'
+
+// interface OrderMenuProps {
+//   menuid: number
+//   menuname: string
+//   menuprice: number
+// }
+
+// const OrderMenuCard: NextPage<OrderMenuProps> = ({
+//   menuid,
+//   menuname,
+//   menuprice,
+// }) => {
+
+// 메뉴아이템 클릭시 ListItem key값이 순서가 업데이트 됨 -39번줄 order1은 임의로 넣은 값임.
+let ListitemKeyValue = ''
+const updateCountOrder = () => {
+  let ordernumber = 0
+  ordernumber++
+  const countOrder = `order ${ordernumber}`
+  ListitemKeyValue = countOrder
+  return countOrder
+}
+
+const Item = styled(Paper)(({ theme }) => ({
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+}))
+
+const OrderMenuCard = (
+  <div>
+    <ListItem key="order1">
+      <Grid container spacing={2}>
+        <Grid item xs={8}>
+          <Item>xs=8</Item>
+        </Grid>
+        <Grid item xs={4}>
+          <Item>xs=4</Item>
+        </Grid>
+        <Grid item xs={4}>
+          <Item>xs=4</Item>
+        </Grid>
+        <Grid item xs={8}>
+          <Item>xs=8</Item>
+        </Grid>
+      </Grid>
+    </ListItem>
+  </div>
+)
+// return OrderMenuCard
+// }
+
+export { OrderMenuCard }


### PR DESCRIPTION
{하드코딩으로 주문 Drawer에 표시될 메뉴 카드 레이아웃 추가}
 - [x] branch명 : OrderDrawerHead
 - [x] 카드레이아웃 그리드 작업
 - [x] OrderMenu.tsx 파일생성
   - [x] 메뉴가 장바구니 담길시, 메뉴를 클릭한 순서대로 ListItem order순서 매겨지는 함수작성(함수명 : updateCountOrder) 
   - [x] 그리드 사용한 OrderMenu 컴포넌트 레이아웃작성 